### PR TITLE
Fix no `flatten` argument error. support old version of mxnet

### DIFF
--- a/code/src/symbol_sentiment.py
+++ b/code/src/symbol_sentiment.py
@@ -33,9 +33,10 @@ def get_sym():
     x = mx.sym.Activation(data = x, act_type = 'relu')
     x = mx.sym.Pooling(data = x, kernel = (3, 3), pool_type = 'max', stride = (2, 2), pooling_convention = 'full')
 
-    x = mx.sym.FullyConnected(data = x, num_hidden = 4096, flatten = True, name = 'fc6_A')
+    x = mx.sym.flatten(x)
+    x = mx.sym.FullyConnected(data = x, num_hidden = 4096, name = 'fc6_A')
     x = mx.sym.Activation(data = x, act_type = 'relu', name = 'relu6_A')
 
-    x = mx.sym.FullyConnected(data = x, num_hidden = 4096, flatten = True, name = 'fc7_A')
+    x = mx.sym.FullyConnected(data = x, num_hidden = 4096, name = 'fc7_A')
     x = mx.sym.Activation(data = x, act_type = 'relu', name = 'relu7_A')
     return x

--- a/code/src/vgg_mx/symbol_vgg.py
+++ b/code/src/vgg_mx/symbol_vgg.py
@@ -23,13 +23,14 @@ class VGG:
         for i, b in enumerate(blocks):
             x = self.vgg_block(x, num_convs = b[0], channels = b[1], block_id = i + 1)
 
-        x = mx.sym.FullyConnected(data = x, num_hidden = 4096, flatten = True, name = 'fc6')
+        x = mx.sym.flatten(x)
+        x = mx.sym.FullyConnected(data = x, num_hidden = 4096, name = 'fc6')
         x = mx.sym.Activation(data = x, act_type = 'relu', name = 'relu6')
         x = mx.sym.Dropout(data = x, p = dropout, name = 'dropout6')
 
-        x = mx.sym.FullyConnected(data = x, num_hidden = 4096, flatten = True, name = 'fc7')
+        x = mx.sym.FullyConnected(data = x, num_hidden = 4096, name = 'fc7')
         x = mx.sym.Activation(data = x, act_type = 'relu', name = 'relu7')
         x = mx.sym.Dropout(data = x, p = dropout, name = 'dropout7')
 
-        x = mx.sym.FullyConnected(data = x, num_hidden = num_classes, flatten = True, name = 'fc8')
+        x = mx.sym.FullyConnected(data = x, num_hidden = num_classes, name = 'fc8')
         return mx.symbol.SoftmaxOutput(data = x, name = 'softmax')


### PR DESCRIPTION
MXNet whose version is lower than 1.12.x doesn't support `flatten` argument in `mxnet.sym.FullyConnected`.
So I use flatten op + FC op to replace the original FC.